### PR TITLE
[fix] api.md markdown

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -153,7 +153,7 @@ $( '#my-slider' ).sliderPro({
 
 >*Example:*
 
->```
+```
 $( '#my-slider' ).sliderPro({
 	width: 960, 
 	height: 400,


### PR DESCRIPTION
File readability was broken from `breakpoints` example up until section 2, Public Methods.